### PR TITLE
Fixed syntax error in example-config

### DIFF
--- a/config-example
+++ b/config-example
@@ -4,7 +4,7 @@
         "gnome-terminal": "term",
         "libreoffice-writer": "writer",
         "libreoffice-calc": "calc",
-        "chromium-browser": "chrome",
+        "chromium-browser": "chrome"
     },
     "instances": {
     }


### PR DESCRIPTION
Thanks for sharing your script!
Trying the example config I got the following error, so I fixed it ;)
> unexpected end of string while parsing JSON string, at character offset 194 (before ",\n    "instances": ...") at ./i3-renameworkspaces.pl line 23.

Best regards!
